### PR TITLE
Everything works as I intended

### DIFF
--- a/faulkner_footsteps/lib/pages/achievement.dart
+++ b/faulkner_footsteps/lib/pages/achievement.dart
@@ -3,14 +3,15 @@ import 'package:provider/provider.dart';
 import 'package:faulkner_footsteps/app_state.dart';
 
 class AchievementsPage extends StatefulWidget {
-
   const AchievementsPage({super.key});
 
   @override
-  AchievementsPageState createState() => AchievementsPageState();
+  AchievementsPageState createState() {
+    return AchievementsPageState();
+  }
 }
 
-class _AchievementsPageState extends State<AchievementsPage> {
+class AchievementsPageState extends State<AchievementsPage> {
   // To track visited places
   void visitPlace(BuildContext context, String place) async {
     // If the place is visited for the first time, a popup will appear and update the state

--- a/faulkner_footsteps/lib/pages/hist_site_page.dart
+++ b/faulkner_footsteps/lib/pages/hist_site_page.dart
@@ -137,15 +137,27 @@ class _HistSitePage extends State<HistSitePage> {
                         SwipeImageGallery(
                           context: context,
                           itemBuilder: (context, galleryIndex) {
-                            return Image.memory(base64Decode(testList.first));
+                            return Image.memory(
+                              base64Decode(testList[index]),
+                              errorBuilder: (context, error, stackTrace) {
+                                return Image.asset(
+                                    'assets/images/faulkner_thumbnail.png');
+                              },
+                            );
                           },
                           itemCount: testList.length,
                         ).show();
                       },
                       child: Padding(
                         padding: const EdgeInsets.all(8.0),
-                        child: Image.memory(base64Decode(testList[index]),
-                            fit: BoxFit.cover),
+                        child: Image.memory(
+                          base64Decode(testList[index]),
+                          fit: BoxFit.cover,
+                          errorBuilder: (context, error, stackTrace) {
+                            return Image.asset(
+                                'assets/images/faulkner_thumbnail.png');
+                          },
+                        ),
                       ),
                     );
                   },

--- a/faulkner_footsteps/lib/pages/map_display.dart
+++ b/faulkner_footsteps/lib/pages/map_display.dart
@@ -14,19 +14,19 @@ import 'package:provider/provider.dart';
 class MapDisplay extends StatefulWidget {
   final LatLng currentPosition;
   final ApplicationState app_state;
-  const MapDisplay({super.key, required this.currentPosition, required this.app_state});
+  const MapDisplay(
+      {super.key, required this.currentPosition, required this.app_state});
 
   @override
   _MapDisplayState createState() => _MapDisplayState();
 }
-
 
 class _MapDisplayState extends State<MapDisplay> {
   bool visited = false;
   final Distance distance = new Distance();
   final Map<String, LatLng> siteLocations = {
     "Buhler Hall": LatLng(35.0991, -92.4422), //done
-    "Cadron Blockhouse": LatLng(35.104633, -92.544917),//maybe done? :')
+    "Cadron Blockhouse": LatLng(35.104633, -92.544917), //maybe done? :')
     "Church of Christ": LatLng(35.0925, -92.4378), //done
     "Conway Confederate Monument": LatLng(35.088571, -92.442956), //done
     "Faulkner County Museum": LatLng(35.0892, -92.4436), //done
@@ -34,22 +34,34 @@ class _MapDisplayState extends State<MapDisplay> {
     "Simon Park": LatLng(35.089967, -92.44085), //done
   };
   late Map<String, double> siteDistances = {
-    "Buhler Hall": distance.as(LengthUnit.Meter, LatLng(35.0991, -92.4422),widget.currentPosition),//done
-    "Cadron Blockhouse": distance.as(LengthUnit.Meter, LatLng(35.104633, -92.544917),widget.currentPosition),//maybe done? :')
-    "Church of Christ": distance.as(LengthUnit.Meter, LatLng(35.0925, -92.4378),widget.currentPosition), //done
-    "Conway Confederate Monument": distance.as(LengthUnit.Meter, LatLng(35.088571, -92.442956),widget.currentPosition), //done
-    "Faulkner County Museum": distance.as(LengthUnit.Meter,  LatLng(35.0892, -92.4436),widget.currentPosition), //done
-    "Hendrix Bell at Altus": distance.as(LengthUnit.Meter, LatLng(35.1, -92.441025),widget.currentPosition), //done
-    "Simon Park": distance.as(LengthUnit.Meter,LatLng(35.089967, -92.44085),widget.currentPosition), //done
+    "Buhler Hall": distance.as(LengthUnit.Meter, LatLng(35.0991, -92.4422),
+        widget.currentPosition), //done
+    "Cadron Blockhouse": distance.as(
+        LengthUnit.Meter,
+        LatLng(35.104633, -92.544917),
+        widget.currentPosition), //maybe done? :')
+    "Church of Christ": distance.as(LengthUnit.Meter, LatLng(35.0925, -92.4378),
+        widget.currentPosition), //done
+    "Conway Confederate Monument": distance.as(LengthUnit.Meter,
+        LatLng(35.088571, -92.442956), widget.currentPosition), //done
+    "Faulkner County Museum": distance.as(LengthUnit.Meter,
+        LatLng(35.0892, -92.4436), widget.currentPosition), //done
+    "Hendrix Bell at Altus": distance.as(LengthUnit.Meter,
+        LatLng(35.1, -92.441025), widget.currentPosition), //done
+    "Simon Park": distance.as(LengthUnit.Meter, LatLng(35.089967, -92.44085),
+        widget.currentPosition), //done
   };
-  late var sorted = Map.fromEntries(siteDistances.entries.toList()..sort((e1, e2) => e1.value.compareTo(e2.value)));
+  late var sorted = Map.fromEntries(siteDistances.entries.toList()
+    ..sort((e1, e2) => e1.value.compareTo(e2.value)));
   late var sortedlist = sorted.values.toList();
- @override
-    void initState() {
+  @override
+  void initState() {
     super.initState();
-    WidgetsBinding.instance.addPostFrameCallback((_) => locationDialog(context));
+    WidgetsBinding.instance
+        .addPostFrameCallback((_) => locationDialog(context));
   }
-  void locationDialog(context){
+
+  void locationDialog(context) {
     final appState = Provider.of<ApplicationState>(context, listen: false);
     HistSite? selectedSite = appState.historicalSites.firstWhere(
       (site) => site.name == sorted.keys.first,
@@ -58,83 +70,88 @@ class _MapDisplayState extends State<MapDisplay> {
         name: sorted.keys.first,
         description: "No description available",
         blurbs: [],
-        images: [],
+        imageUrls: [],
         avgRating: 0.0,
         ratingAmount: 0,
       ),
     );
     print(sorted.values.first);
-    if ((sorted.values.first < 30000.0) &  (!appState.hasVisited(sorted.keys.first)) & !visited ){
-      showDialog(context: context, 
-      builder: (BuildContext context,){
-      return AlertDialog(
-      backgroundColor: const Color.fromARGB(255, 247, 222, 231),
-      title: Text("You are near a historical site!"),
-      content: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Text(sorted.keys.first),
-          TextButton(
-            onPressed: () {
-              Navigator.of(context).pop();
-              // Navigate User to the HistSitePage
-              Navigator.push(
-                context,
-                MaterialPageRoute(
-                  builder: (context) => HistSitePage(
-                    histSite: selectedSite,
-                    app_state: appState,
+    if ((sorted.values.first < 30000.0) &
+        (!appState.hasVisited(sorted.keys.first)) &
+        !visited) {
+      showDialog(
+          context: context,
+          builder: (
+            BuildContext context,
+          ) {
+            return AlertDialog(
+              backgroundColor: const Color.fromARGB(255, 247, 222, 231),
+              title: Text("You are near a historical site!"),
+              content: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(sorted.keys.first),
+                  TextButton(
+                    onPressed: () {
+                      Navigator.of(context).pop();
+                      // Navigate User to the HistSitePage
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (context) => HistSitePage(
+                            histSite: selectedSite,
+                            app_state: appState,
+                          ),
+                        ),
+                      );
+                    },
+                    child: const Text(
+                      "Get Info",
+                      style: TextStyle(
+                        fontSize: 20.0,
+                        color: Color.fromARGB(255, 2, 26, 77),
+                      ),
+                    ),
                   ),
-                ),
-              );
-            },
-            child: const Text(
-              "Get Info",
-              style: TextStyle(
-                fontSize: 20.0,
-                color: Color.fromARGB(255, 2, 26, 77),
+                  TextButton(
+                    onPressed: () {
+                      Navigator.of(context).pop();
+                      var AchievementState = AchievementsPageState();
+                      // Navigate User to the HistSitePage
+                      AchievementState.visitPlace(context, sorted.keys.first);
+                      visited = true;
+                    },
+                    child: const Text(
+                      "Mark as visited.",
+                      style: TextStyle(
+                        fontSize: 20.0,
+                        color: Color.fromARGB(255, 2, 26, 77),
+                      ),
+                    ),
+                  ),
+                  TextButton(
+                    onPressed: () {
+                      Navigator.of(context).pop();
+                      var AchievementState = AchievementsPageState();
+                      // Navigate User to the HistSitePage
+                      AchievementState.visitPlace(context, sorted.keys.first);
+                      visited = true;
+                    },
+                    child: const Text(
+                      "Close",
+                      style: TextStyle(
+                        fontSize: 20.0,
+                        color: Color.fromARGB(255, 2, 26, 77),
+                      ),
+                    ),
+                  ),
+                ],
               ),
-            ),
-          ),
-          TextButton(
-            onPressed: () {
-              Navigator.of(context).pop();
-              var AchievementState = AchievementsPageState();
-              // Navigate User to the HistSitePage
-              AchievementState.visitPlace(context, sorted.keys.first);
-              visited = true;
-            },
-            child: const Text(
-              "Mark as visited.",
-              style: TextStyle(
-                fontSize: 20.0,
-                color: Color.fromARGB(255, 2, 26, 77),
-              ),
-            ),
-          ),
-          TextButton(
-            onPressed: () {
-              Navigator.of(context).pop();
-              var AchievementState = AchievementsPageState();
-              // Navigate User to the HistSitePage
-              AchievementState.visitPlace(context, sorted.keys.first);
-              visited = true;
-            },
-            child: const Text(
-              "Close",
-              style: TextStyle(
-                fontSize: 20.0,
-                color: Color.fromARGB(255, 2, 26, 77),
-              ),
-            ),
-          ),
-        ],
-      ),
-    );
-    });
+            );
+          });
+    }
   }
-  }
-  
+
   @override
   Widget build(BuildContext context) {
     return Consumer<ApplicationState>(
@@ -144,7 +161,8 @@ class _MapDisplayState extends State<MapDisplay> {
           return Marker(
             point: entry.value,
             child: IconButton(
-              icon: const Icon(Icons.location_pin, color: Color.fromARGB(255, 255, 70, 57), size: 30),
+              icon: const Icon(Icons.location_pin,
+                  color: Color.fromARGB(255, 255, 70, 57), size: 30),
               onPressed: () {
                 // Show PinDialog when a pin is clicked
                 showDialog(
@@ -160,7 +178,7 @@ class _MapDisplayState extends State<MapDisplay> {
             ),
           );
         }).toList();
-          return Scaffold(
+        return Scaffold(
           backgroundColor: const Color.fromARGB(255, 238, 214, 196),
           appBar: AppBar(
             backgroundColor: const Color.fromARGB(255, 107, 79, 79),
@@ -188,8 +206,8 @@ class _MapDisplayState extends State<MapDisplay> {
               ),
             ],
           ),
-      );},
-      );
+        );
+      },
+    );
   }
 }
-


### PR DESCRIPTION
Closes #23 
Closes #17 

The achievements page is now no longer reliant on the achievements list being hard coded. It takes in historical sites collection on the Firebase. I created a test site to test this and it works perfectly.
When an invalid image is given and an error appears, the basic faulkner footsteps thumbnail will appear instead of the error. 
When you click on an image in the gallery image, the correct one displays, not just the first one in the image list. I noticed that @Jkwashu made a commit on his branch that tried to fix this, but this code actually fixes it I believe. 

Sorry this doesn't merge easily, I don't understand why GitHub is acting funny with this