### PR TITLE
Changed app images to be firebase storage dependent, improved filter selection

### DIFF
--- a/faulkner_footsteps/lib/app_router.dart
+++ b/faulkner_footsteps/lib/app_router.dart
@@ -35,7 +35,6 @@ class AppRouter {
                   value:
                       "An error has appeared when trying to navigate to a page for this historical site. Please restart the app.")
             ],
-            images: [],
             imageUrls: [],
             lat: 0,
             lng: 0,

--- a/faulkner_footsteps/lib/app_state.dart
+++ b/faulkner_footsteps/lib/app_state.dart
@@ -79,14 +79,11 @@ class ApplicationState extends ChangeNotifier {
                     "Filter not found in siteFilter enum list. Filter: $filter");
               }
             }
-
-            _historicalSites.add(HistSite(
+            HistSite site = HistSite(
               name: document.data()["name"] as String,
               description: document.data()["description"] as String,
               blurbs: newBlurbs,
               imageUrls: List<String>.from(document.data()["images"]),
-              images: await getImageList(
-                  List<String>.from(document.data()["images"])),
               lat: document.data()["lat"] as double,
               lng: document.data()["lng"] as double,
               filters: filters,
@@ -98,7 +95,9 @@ class ApplicationState extends ChangeNotifier {
               ratingAmount: document.data()["ratingCount"] != null
                   ? document.data()["ratingCount"] as int
                   : 0,
-            ));
+            );
+            _historicalSites.add(site);
+            loadImageToHistSite(document, site);
           }
           //print(historicalSites);
           notifyListeners();
@@ -151,6 +150,16 @@ class ApplicationState extends ChangeNotifier {
       rList.add(item);
     }
     return rList;
+  }
+
+  //TODO: implement this!!!
+  // load all the images to the hist site
+  Future<void> loadImageToHistSite(
+      QueryDocumentSnapshot<Map<String, dynamic>> document,
+      HistSite site) async {
+    List<Uint8List?> imgList =
+        await getImageList(List<String>.from(document.data()["images"]));
+    site.images = imgList;
   }
 
   void addSite(HistSite newSite) {

--- a/faulkner_footsteps/lib/app_state.dart
+++ b/faulkner_footsteps/lib/app_state.dart
@@ -125,6 +125,7 @@ class ApplicationState extends ChangeNotifier {
     } catch (e) {
       // Handle any errors.
       print(("ERROR!!! This occured when calling getImage(). Error: $e"));
+      print("Error is for $s");
     } finally {}
     return data;
   }

--- a/faulkner_footsteps/lib/dialogs/create_site_dialogue.dart
+++ b/faulkner_footsteps/lib/dialogs/create_site_dialogue.dart
@@ -112,7 +112,6 @@ class _siteDialogueState extends State<SiteDialogue> {
                                 blurbs: newBlurbs,
                                 description: descText,
                                 imageUrls: [],
-                                images: [],
                                 filters: [],
                                 ratingAmount: 0,
                                 avgRating: 0.0,

--- a/faulkner_footsteps/lib/dialogs/pin_Dialog.dart
+++ b/faulkner_footsteps/lib/dialogs/pin_Dialog.dart
@@ -27,7 +27,6 @@ class PinDialog extends StatelessWidget {
         name: siteName,
         description: "No description available",
         blurbs: [],
-        images: [],
         imageUrls: [],
         filters: [],
         lat: 0,

--- a/faulkner_footsteps/lib/main.dart
+++ b/faulkner_footsteps/lib/main.dart
@@ -97,7 +97,6 @@ class _MyHomePageState extends State<MyHomePage> {
               value:
                   "This does not have a date but we still exist beyond the current state of human understanding and everything is something to another ellos")
         ],
-        images: [],
         imageUrls: [],
         filters: [],
         //added ratings here
@@ -136,7 +135,6 @@ class _MyHomePageState extends State<MyHomePage> {
             title: "Significance",
             value: "It played a major role in local history."),
       ],
-      images: [],
       imageUrls: [
         /*
         AssetImage('assets/images/AutobotLogo.png'),

--- a/faulkner_footsteps/lib/objects/hist_site.dart
+++ b/faulkner_footsteps/lib/objects/hist_site.dart
@@ -14,7 +14,6 @@ class HistSite {
       required this.imageUrls,
       required this.avgRating,
       required this.ratingAmount,
-      required this.images,
       required this.lat,
       required this.lng,
       required this.filters});
@@ -23,13 +22,17 @@ class HistSite {
   String name;
   String description;
   List<InfoText> blurbs;
-  List<Uint8List?> images;
+  List<Uint8List?> images = [];
   List<String> imageUrls;
   double avgRating;
   int ratingAmount;
   double lat;
   double lng;
   List<siteFilter> filters;
+
+  void updateImage(List<Uint8List?> images) {
+    this.images = images;
+  }
 
   String listifyBlurbs() {
     String fin = "";

--- a/faulkner_footsteps/lib/objects/hist_site.dart
+++ b/faulkner_footsteps/lib/objects/hist_site.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:faulkner_footsteps/dialogs/filter_Dialog.dart';
 import 'package:flutter/material.dart';
 
@@ -21,7 +23,7 @@ class HistSite {
   String name;
   String description;
   List<InfoText> blurbs;
-  List<String> images;
+  List<Uint8List?> images;
   List<String> imageUrls;
   double avgRating;
   int ratingAmount;

--- a/faulkner_footsteps/lib/objects/list_item.dart
+++ b/faulkner_footsteps/lib/objects/list_item.dart
@@ -64,21 +64,28 @@ class ListItem extends StatelessWidget {
               ClipRRect(
                 borderRadius:
                     const BorderRadius.vertical(top: Radius.circular(12)),
-                child: Image.memory(
-                  // 'assets/images/faulkner_thumbnail.png',
-                  // 'assets/images/faulkner_thumbnail.png', <- this is for the original thumbnail the classroom group was using
-                  siteInfo.images.first != null
-                      ? siteInfo.images.first!
-                      : Uint8List(0),
-                  height:
-                      400, // Adjust height as needed. 400 seems to work best with the images. This was originally at 150
-                  width: double.infinity,
-                  fit: BoxFit.cover,
+                child: siteInfo.images.first != null
+                    ? Image.memory(
+                        // 'assets/images/faulkner_thumbnail.png',
+                        // 'assets/images/faulkner_thumbnail.png', <- this is for the original thumbnail the classroom group was using
+                        siteInfo.images.first!,
+                        height:
+                            400, // Adjust height as needed. 400 seems to work best with the images. This was originally at 150
+                        width: double.infinity,
+                        fit: BoxFit.cover,
 
-                  // errorBuilder: (context, error, stackTrace) {
-                  //   return Image.asset('assets/images/faulkner_thumbnail.png');
-                  // },
-                ),
+                        errorBuilder: (context, error, stackTrace) {
+                          return Image.asset(
+                              'assets/images/faulkner_thumbnail.png');
+                        },
+                      )
+                    : Image.asset(
+                        'assets/images/faulkner_thumbnail.png',
+                        height:
+                            400, // Adjust height as needed. 400 seems to work best with the images. This was originally at 150
+                        width: double.infinity,
+                        fit: BoxFit.cover,
+                      ),
               ),
               // Row with text and icon inline
               Padding(

--- a/faulkner_footsteps/lib/objects/list_item.dart
+++ b/faulkner_footsteps/lib/objects/list_item.dart
@@ -64,7 +64,7 @@ class ListItem extends StatelessWidget {
               ClipRRect(
                 borderRadius:
                     const BorderRadius.vertical(top: Radius.circular(12)),
-                child: siteInfo.images.first != null
+                child: siteInfo.images.length > 0
                     ? Image.memory(
                         // 'assets/images/faulkner_thumbnail.png',
                         // 'assets/images/faulkner_thumbnail.png', <- this is for the original thumbnail the classroom group was using

--- a/faulkner_footsteps/lib/objects/list_item.dart
+++ b/faulkner_footsteps/lib/objects/list_item.dart
@@ -5,6 +5,8 @@ import 'dart:convert';
 import 'package:faulkner_footsteps/app_router.dart';
 import 'package:faulkner_footsteps/app_state.dart';
 import 'package:faulkner_footsteps/objects/hist_site.dart';
+import 'package:firebase_storage/firebase_storage.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:latlong2/latlong.dart';
@@ -23,6 +25,7 @@ class ListItem extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // setImages();
     String siteDistance = (_distance.as(LengthUnit.Meter,
                 LatLng(siteInfo.lat, siteInfo.lng), currentPosition) /
             1609.344)
@@ -64,17 +67,17 @@ class ListItem extends StatelessWidget {
                 child: Image.memory(
                   // 'assets/images/faulkner_thumbnail.png',
                   // 'assets/images/faulkner_thumbnail.png', <- this is for the original thumbnail the classroom group was using
-                  // siteInfo.imageUrls.first,
-
-                  base64Decode(siteInfo.imageUrls.first),
+                  siteInfo.images.first != null
+                      ? siteInfo.images.first!
+                      : Uint8List(0),
                   height:
                       400, // Adjust height as needed. 400 seems to work best with the images. This was originally at 150
                   width: double.infinity,
                   fit: BoxFit.cover,
 
-                  errorBuilder: (context, error, stackTrace) {
-                    return Image.asset('assets/images/faulkner_thumbnail.png');
-                  },
+                  // errorBuilder: (context, error, stackTrace) {
+                  //   return Image.asset('assets/images/faulkner_thumbnail.png');
+                  // },
                 ),
               ),
               // Row with text and icon inline

--- a/faulkner_footsteps/lib/objects/list_item.dart
+++ b/faulkner_footsteps/lib/objects/list_item.dart
@@ -64,7 +64,7 @@ class ListItem extends StatelessWidget {
               ClipRRect(
                 borderRadius:
                     const BorderRadius.vertical(top: Radius.circular(12)),
-                child: siteInfo.images.length > 0
+                child: siteInfo.images.length > 0 && siteInfo.images[0] != null
                     ? Image.memory(
                         // 'assets/images/faulkner_thumbnail.png',
                         // 'assets/images/faulkner_thumbnail.png', <- this is for the original thumbnail the classroom group was using

--- a/faulkner_footsteps/lib/pages/admin_page.dart
+++ b/faulkner_footsteps/lib/pages/admin_page.dart
@@ -57,16 +57,13 @@ class _AdminListPageState extends State<AdminListPage> {
     setState(() {});
   }
 
-  Future<void> uploadImage(String fileName) async {
-    final imagesRef = storageRef.child("images");
-
+  Future<String> uploadImage(String fileName) async {
 // // Create the file metadata
     final metadata = SettableMetadata(contentType: "image/jpeg");
 
 // Upload file and metadata. Metadata ensures it is saved in jpg format
-
-    final uploadTask =
-        imagesRef.child("$fileName.jpg").putFile(image!, metadata);
+    final path = "images/$fileName.jpg";
+    final uploadTask = storageRef.child(path).putFile(image!, metadata);
 
 // Listen for state changes, errors, and completion of the upload.
     uploadTask.snapshotEvents.listen((TaskSnapshot taskSnapshot) {
@@ -91,6 +88,7 @@ class _AdminListPageState extends State<AdminListPage> {
           break;
       }
     });
+    return path; //path is what we will store in firebase
   }
 
   Future<String> imageFiletoBase64(File? imageFile) async {
@@ -259,12 +257,12 @@ class _AdminListPageState extends State<AdminListPage> {
                     //I think putting an async here is fine.
                     if (nameController.text.isNotEmpty &&
                         descriptionController.text.isNotEmpty) {
-                      uploadImage(nameController.text);
+                      String path = await uploadImage(nameController.text);
                       final newSite = HistSite(
                         name: nameController.text,
                         description: descriptionController.text,
                         blurbs: blurbs,
-                        images: [],
+                        images: [path],
                         imageUrls: [],
                         avgRating: 0.0,
                         ratingAmount: 0,

--- a/faulkner_footsteps/lib/pages/admin_page.dart
+++ b/faulkner_footsteps/lib/pages/admin_page.dart
@@ -63,6 +63,9 @@ class _AdminListPageState extends State<AdminListPage> {
 // // Create the file metadata
     final metadata = SettableMetadata(contentType: "image/jpeg");
 
+// Change the filename to a string that has no spaces
+    fileName = fileName.replaceAll(" ", "_");
+
 // Upload file and metadata. Metadata ensures it is saved in jpg format
     final path = "images/$folderName/$fileName.jpg";
     final uploadTask = storageRef.child(path).putFile(image!, metadata);

--- a/faulkner_footsteps/lib/pages/admin_page.dart
+++ b/faulkner_footsteps/lib/pages/admin_page.dart
@@ -12,6 +12,7 @@ import 'package:google_fonts/google_fonts.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:latlong2/latlong.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:uuid/uuid.dart';
 
 class AdminListPage extends StatefulWidget {
   AdminListPage({super.key});
@@ -27,6 +28,7 @@ class _AdminListPageState extends State<AdminListPage> {
   File? image;
   final storage = FirebaseStorage.instance;
   final storageRef = FirebaseStorage.instance.ref();
+  var uuid = Uuid();
 
   @override
   void initState() {
@@ -243,8 +245,9 @@ class _AdminListPageState extends State<AdminListPage> {
                     //I think putting an async here is fine.
                     if (nameController.text.isNotEmpty &&
                         descriptionController.text.isNotEmpty) {
+                      String randomName = uuid.v4();
                       String path = await uploadImage(nameController.text,
-                          "first"); //TODO: change "first" so that the file name makes sense and is unique
+                          randomName); //TODO: change "first" so that the file name makes sense and is unique
                       final newSite = HistSite(
                         name: nameController.text,
                         description: descriptionController.text,

--- a/faulkner_footsteps/lib/pages/admin_page.dart
+++ b/faulkner_footsteps/lib/pages/admin_page.dart
@@ -64,7 +64,7 @@ class _AdminListPageState extends State<AdminListPage> {
 // final metadata = SettableMetadata(contentType: "image/jpeg");
 
 // Upload file and metadata to the path 'images/mountains.jpg'
-    final uploadTask = imagesRef.child("images").putFile(image!);
+    final uploadTask = imagesRef.child("images.jpg").putFile(image!);
 
 // Listen for state changes, errors, and completion of the upload.
     uploadTask.snapshotEvents.listen((TaskSnapshot taskSnapshot) {

--- a/faulkner_footsteps/lib/pages/admin_page.dart
+++ b/faulkner_footsteps/lib/pages/admin_page.dart
@@ -219,8 +219,6 @@ class _AdminListPageState extends State<AdminListPage> {
                       ),
                       onPressed: () async {
                         await pickImage();
-                        print("here");
-                        print("Image: ${this.image}");
                         setState(
                             () {}); //idk why, but setState is acting weird here but it works now
                       },
@@ -233,7 +231,7 @@ class _AdminListPageState extends State<AdminListPage> {
                           ? Image.file(image!,
                               width: 160, height: 160, fit: BoxFit.contain)
                           : FlutterLogo()
-                    ]
+                    ],
                   ],
                 ),
               ),

--- a/faulkner_footsteps/lib/pages/admin_page.dart
+++ b/faulkner_footsteps/lib/pages/admin_page.dart
@@ -249,7 +249,6 @@ class _AdminListPageState extends State<AdminListPage> {
                         name: nameController.text,
                         description: descriptionController.text,
                         blurbs: blurbs,
-                        images: [],
                         imageUrls: [path],
                         avgRating: 0.0,
                         ratingAmount: 0,
@@ -487,7 +486,6 @@ class _AdminListPageState extends State<AdminListPage> {
                       name: nameController.text,
                       description: descriptionController.text,
                       blurbs: blurbs,
-                      images: [], // Using empty list since we're working with imageUrls
                       imageUrls: site.imageUrls,
                       avgRating: site.avgRating,
                       ratingAmount: site.ratingAmount,

--- a/faulkner_footsteps/lib/pages/admin_page.dart
+++ b/faulkner_footsteps/lib/pages/admin_page.dart
@@ -57,14 +57,16 @@ class _AdminListPageState extends State<AdminListPage> {
     setState(() {});
   }
 
-  Future<void> uploadImage() async {
+  Future<void> uploadImage(String fileName) async {
     final imagesRef = storageRef.child("images");
 
 // // Create the file metadata
-// final metadata = SettableMetadata(contentType: "image/jpeg");
+    final metadata = SettableMetadata(contentType: "image/jpeg");
 
-// Upload file and metadata to the path 'images/mountains.jpg'
-    final uploadTask = imagesRef.child("images.jpg").putFile(image!);
+// Upload file and metadata. Metadata ensures it is saved in jpg format
+
+    final uploadTask =
+        imagesRef.child("$fileName.jpg").putFile(image!, metadata);
 
 // Listen for state changes, errors, and completion of the upload.
     uploadTask.snapshotEvents.listen((TaskSnapshot taskSnapshot) {
@@ -257,7 +259,7 @@ class _AdminListPageState extends State<AdminListPage> {
                     //I think putting an async here is fine.
                     if (nameController.text.isNotEmpty &&
                         descriptionController.text.isNotEmpty) {
-                      uploadImage();
+                      uploadImage(nameController.text);
                       final newSite = HistSite(
                         name: nameController.text,
                         description: descriptionController.text,

--- a/faulkner_footsteps/lib/pages/admin_page.dart
+++ b/faulkner_footsteps/lib/pages/admin_page.dart
@@ -91,20 +91,6 @@ class _AdminListPageState extends State<AdminListPage> {
     return path; //path is what we will store in firebase
   }
 
-  Future<String> imageFiletoBase64(File? imageFile) async {
-    //I want to allow the imagefile to be null so that it is possible to create a site w/o an image
-    //https: //community.flutterflow.io/c/community-custom-widgets/post/view-local-files-and-uploading-them-to-firestore-dfvxUu2ojKQlTwu
-    var bytes;
-    if (imageFile == null) {
-      print("imageFile is null!");
-      return "";
-    }
-    bytes = File(imageFile.path).readAsBytesSync();
-    String image64 = base64Encode(bytes);
-    print("Function call image64: $image64");
-    return image64;
-  }
-
   void _onItemTapped(int index) {
     if (index == 1) {
       Navigator.push(
@@ -262,8 +248,8 @@ class _AdminListPageState extends State<AdminListPage> {
                         name: nameController.text,
                         description: descriptionController.text,
                         blurbs: blurbs,
-                        images: [path],
-                        imageUrls: [],
+                        images: [],
+                        imageUrls: [path],
                         avgRating: 0.0,
                         ratingAmount: 0,
                         filters: [],

--- a/faulkner_footsteps/lib/pages/admin_page.dart
+++ b/faulkner_footsteps/lib/pages/admin_page.dart
@@ -57,12 +57,12 @@ class _AdminListPageState extends State<AdminListPage> {
     setState(() {});
   }
 
-  Future<String> uploadImage(String fileName) async {
+  Future<String> uploadImage(String folderName, String fileName) async {
 // // Create the file metadata
     final metadata = SettableMetadata(contentType: "image/jpeg");
 
 // Upload file and metadata. Metadata ensures it is saved in jpg format
-    final path = "images/$fileName.jpg";
+    final path = "images/$folderName/$fileName.jpg";
     final uploadTask = storageRef.child(path).putFile(image!, metadata);
 
 // Listen for state changes, errors, and completion of the upload.
@@ -243,7 +243,8 @@ class _AdminListPageState extends State<AdminListPage> {
                     //I think putting an async here is fine.
                     if (nameController.text.isNotEmpty &&
                         descriptionController.text.isNotEmpty) {
-                      String path = await uploadImage(nameController.text);
+                      String path = await uploadImage(nameController.text,
+                          "first"); //TODO: change "first" so that the file name makes sense and is unique
                       final newSite = HistSite(
                         name: nameController.text,
                         description: descriptionController.text,

--- a/faulkner_footsteps/lib/pages/admin_page.dart
+++ b/faulkner_footsteps/lib/pages/admin_page.dart
@@ -64,7 +64,9 @@ class _AdminListPageState extends State<AdminListPage> {
     final metadata = SettableMetadata(contentType: "image/jpeg");
 
 // Change the filename to a string that has no spaces
-    fileName = fileName.replaceAll(" ", "_");
+    // folderName.replaceAll(' ', '_');
+    folderName.split(" ").join("_");
+    print("FileName: $folderName");
 
 // Upload file and metadata. Metadata ensures it is saved in jpg format
     final path = "images/$folderName/$fileName.jpg";

--- a/faulkner_footsteps/lib/pages/hist_site_page.dart
+++ b/faulkner_footsteps/lib/pages/hist_site_page.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:typed_data';
 
 import 'package:faulkner_footsteps/app_state.dart';
 import 'package:faulkner_footsteps/dialogs/rating_Dialog.dart';
@@ -98,7 +99,6 @@ class _HistSitePage extends State<HistSitePage> {
                 widget.currentPosition) /
             1609.344)
         .toStringAsFixed(2);
-    List<String> testList = widget.histSite.imageUrls;
     return Scaffold(
         backgroundColor: const Color.fromARGB(255, 238, 214, 196),
         appBar: AppBar(
@@ -177,35 +177,35 @@ class _HistSitePage extends State<HistSitePage> {
                 height: 200,
                 child: ListView.builder(
                   scrollDirection: Axis.horizontal,
-                  itemCount: testList.length,
+                  itemCount: widget.histSite.images.length,
                   itemBuilder: (context, index) {
                     return GestureDetector(
                       onTap: () {
                         SwipeImageGallery(
                           context: context,
                           itemBuilder: (context, galleryIndex) {
-                            return Image.memory(
-                              base64Decode(testList[index]),
-                              fit: BoxFit.contain,
-                              errorBuilder: (context, error, stackTrace) {
-                                return Image.asset(
-                                    "assets/images/faulkner_thumbnail.png");
-                              },
-                            );
+                            return widget.histSite.images[index] != null
+                                ? Image.memory(
+                                    widget.histSite.images[index]!,
+                                    fit: BoxFit.contain,
+                                  )
+                                : Image.asset(
+                                    "assets/images/faulkner_thumbnail.png",
+                                    fit: BoxFit.contain);
                           },
-                          itemCount: testList.length,
+                          itemCount: widget.histSite.images.length,
                         ).show();
                       },
                       child: Padding(
                         padding: const EdgeInsets.all(8.0),
-                        child: Image.memory(
-                          base64Decode(testList[index]),
-                          fit: BoxFit.cover,
-                          errorBuilder: (context, error, stackTrace) {
-                            return Image.asset(
-                                "assets/images/faulkner_thumbnail.png");
-                          },
-                        ),
+                        child: widget.histSite.images[index] != null
+                            ? Image.memory(
+                                widget.histSite.images[index]!,
+                                fit: BoxFit.contain,
+                              )
+                            : Image.asset(
+                                "assets/images/faulkner_thumbnail.png",
+                                fit: BoxFit.contain),
                       ),
                     );
                   },

--- a/faulkner_footsteps/lib/pages/list_page.dart
+++ b/faulkner_footsteps/lib/pages/list_page.dart
@@ -128,42 +128,17 @@ class _ListPageState extends State<ListPage> {
             itemBuilder: (BuildContext context, int index) {
               if (index == 0) {
                 return Container(
-                  padding: EdgeInsets.all(16),
                   // height: MediaQuery.of(context).size.height,
-                  height: MediaQuery.of(context).size.height / 10,
-                  child: ListView.builder(
-                    itemCount: siteFilter.values.length + 1,
-                    scrollDirection: Axis.horizontal,
-                    itemBuilder: (context, index) {
-                      if (index == 0) {
-                        return TextButton(
-                            style: ButtonStyle(
-                              // overlayColor: WidgetStatePropertyAll(
-                              //     Color.fromARGB(255, 107, 79, 79)),
-                              overlayColor:
-                                  WidgetStatePropertyAll(Colors.transparent),
-                              maximumSize: WidgetStatePropertyAll(
-                                  Size(MediaQuery.of(context).size.width, 50)),
-                              // backgroundColor: WidgetStatePropertyAll(
-                              //     Color.fromARGB(255, 107, 79, 79))
-                            ),
-                            onPressed: () {
-                              setState(() {
-                                activeFilters.clear();
-                                filterChangedCallback();
-                              });
-                            },
-                            child: Text(
-                              "Clear Filters (${activeFilters.length})",
-                              style: GoogleFonts.ultra(
-                                  textStyle: TextStyle(
-                                      color: Color.fromARGB(255, 107, 79, 79)),
-                                  fontSize: 14),
-                            ));
-                      } else {
-                        siteFilter currentFilter = siteFilter.values[index - 1];
+                  height: MediaQuery.of(context).size.height / 9,
+                  child: Stack(children: [
+                    ListView.builder(
+                      itemCount: siteFilter.values.length,
+                      scrollDirection: Axis.horizontal,
+                      itemBuilder: (context, index) {
+                        siteFilter currentFilter = siteFilter.values[index];
                         return Padding(
-                          padding: EdgeInsets.all(8),
+                          padding: EdgeInsets.fromLTRB(8, 32, 8, 16),
+                          // padding: EdgeInsets.all(8),
                           child: FilterChip(
                             backgroundColor: Color.fromARGB(255, 255, 243, 228),
                             disabledColor: Color.fromARGB(255, 255, 243, 228),
@@ -190,10 +165,41 @@ class _ListPageState extends State<ListPage> {
                             },
                           ),
                         );
-                      }
-                    },
-                    // children: siteFilter.values.map((siteFilter filter) {
-                  ),
+                      },
+                      // children: siteFilter.values.map((siteFilter filter) {
+                    ),
+                    Align(
+                      child: Container(
+                        // padding: EdgeInsets.fromLTRB(0, 0, 0, 32),
+                        child: TextButton(
+                            style: ButtonStyle(
+                              // overlayColor: WidgetStatePropertyAll(
+                              //     Color.fromARGB(255, 107, 79, 79)),
+                              overlayColor:
+                                  WidgetStatePropertyAll(Colors.transparent),
+                              maximumSize: WidgetStatePropertyAll(
+                                  Size(MediaQuery.of(context).size.width, 50)),
+                              // backgroundColor: WidgetStatePropertyAll(
+                              //     Color.fromARGB(255, 107, 79, 79))
+                            ),
+                            onPressed: () {
+                              setState(() {
+                                activeFilters.clear();
+                                filterChangedCallback();
+                              });
+                            },
+                            child: Text(
+                              "Clear (${activeFilters.length})",
+                              style: GoogleFonts.ultra(
+                                  textStyle: TextStyle(
+                                      decoration: TextDecoration.underline,
+                                      color: Color.fromARGB(255, 107, 79, 79)),
+                                  fontSize: 14),
+                            )),
+                      ),
+                      alignment: Alignment.topRight,
+                    ),
+                  ]),
                 );
               } else {
                 HistSite site = displaySites[index - 1];
@@ -430,17 +436,6 @@ class _ListPageState extends State<ListPage> {
               icon: const Icon(Icons.search,
                   color: Color.fromARGB(255, 255, 243, 228)),
             ),
-            IconButton(
-                color: Color.fromARGB(255, 255, 243, 228),
-                onPressed: () {
-                  showDialog(
-                      context: context,
-                      builder: (context) => FilterDialog(
-                            activeFilters: activeFilters,
-                            onFiltersChanged: filterChangedCallback,
-                          ));
-                },
-                icon: Icon(Icons.filter_alt_sharp))
           ],
           title: Container(
             constraints: BoxConstraints(

--- a/faulkner_footsteps/lib/pages/list_page.dart
+++ b/faulkner_footsteps/lib/pages/list_page.dart
@@ -189,7 +189,9 @@ class _ListPageState extends State<ListPage> {
                               });
                             },
                             child: Text(
-                              "Clear (${activeFilters.length})",
+                              activeFilters.length > 0
+                                  ? "Clear (${activeFilters.length})"
+                                  : "",
                               style: GoogleFonts.ultra(
                                   textStyle: TextStyle(
                                       decoration: TextDecoration.underline,

--- a/faulkner_footsteps/lib/pages/list_page.dart
+++ b/faulkner_footsteps/lib/pages/list_page.dart
@@ -90,7 +90,7 @@ class _ListPageState extends State<ListPage> {
     fullSiteList = widget.app_state.historicalSites;
     activeFilters = [];
     searchSites = fullSiteList;
-    print("INIT STATE");
+    // print("INIT STATE");
 
     _searchController = SearchController();
     super.initState();

--- a/faulkner_footsteps/lib/pages/map_display.dart
+++ b/faulkner_footsteps/lib/pages/map_display.dart
@@ -56,7 +56,6 @@ class _MapDisplayState extends State<MapDisplay> {
         name: sorted.keys.first,
         description: "No description available",
         blurbs: [],
-        images: [],
         imageUrls: [],
         filters: [],
         lat: 0,

--- a/faulkner_footsteps/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/faulkner_footsteps/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -11,6 +11,7 @@ import desktop_webview_auth
 import file_selector_macos
 import firebase_auth
 import firebase_core
+import firebase_storage
 import geolocator_apple
 import path_provider_foundation
 import url_launcher_macos
@@ -22,6 +23,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
   FLTFirebaseAuthPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseAuthPlugin"))
   FLTFirebaseCorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCorePlugin"))
+  FLTFirebaseStoragePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseStoragePlugin"))
   GeolocatorPlugin.register(with: registry.registrar(forPlugin: "GeolocatorPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))

--- a/faulkner_footsteps/pubspec.lock
+++ b/faulkner_footsteps/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: _flutterfire_internals
-      sha256: "71c01c1998c40b3af1944ad0a5f374b4e6fef7f3d2df487f3970dbeadaeb25a1"
+      sha256: "7fd72d77a7487c26faab1d274af23fb008763ddc10800261abbfb2c067f183d5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.46"
+    version: "1.3.53"
   archive:
     dependency: transitive
     description:
@@ -293,26 +293,26 @@ packages:
     dependency: "direct main"
     description:
       name: firebase_core
-      sha256: "2438a75ad803e818ad3bd5df49137ee619c46b6fc7101f4dbc23da07305ce553"
+      sha256: f4d8f49574a4e396f34567f3eec4d38ab9c3910818dec22ca42b2a467c685d8b
       url: "https://pub.dev"
     source: hosted
-    version: "3.8.0"
+    version: "3.12.1"
   firebase_core_platform_interface:
     dependency: transitive
     description:
       name: firebase_core_platform_interface
-      sha256: e30da58198a6d4b49d5bce4e852f985c32cb10db329ebef9473db2b9f09ce810
+      sha256: d7253d255ff10f85cfd2adaba9ac17bae878fa3ba577462451163bd9f1d1f0bf
       url: "https://pub.dev"
     source: hosted
-    version: "5.3.0"
+    version: "5.4.0"
   firebase_core_web:
     dependency: transitive
     description:
       name: firebase_core_web
-      sha256: f967a7138f5d2ffb1ce15950e2a382924239eaa521150a8f144af34e68b3b3e5
+      sha256: faa5a76f6380a9b90b53bc3bdcb85bc7926a382e0709b9b5edac9f7746651493
       url: "https://pub.dev"
     source: hosted
-    version: "2.18.1"
+    version: "2.21.1"
   firebase_dynamic_links:
     dependency: transitive
     description:
@@ -329,6 +329,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.6+46"
+  firebase_storage:
+    dependency: "direct main"
+    description:
+      name: firebase_storage
+      sha256: "2274bb277d0d56d4a106fd89bad5e8f7c005bae77dc3df5abd36101957010840"
+      url: "https://pub.dev"
+    source: hosted
+    version: "12.4.4"
+  firebase_storage_platform_interface:
+    dependency: transitive
+    description:
+      name: firebase_storage_platform_interface
+      sha256: "36ed6ebc2453a500c6d1e63c8126459056a70a798d53636242b0325951814cf5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.2.4"
+  firebase_storage_web:
+    dependency: transitive
+    description:
+      name: firebase_storage_web
+      sha256: e169fc825cbd91c70d73f75b7e8be9ada272b4297184f779ca124b42945828fe
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.10.11"
   firebase_ui_auth:
     dependency: "direct main"
     description:

--- a/faulkner_footsteps/pubspec.lock
+++ b/faulkner_footsteps/pubspec.lock
@@ -1003,7 +1003,7 @@ packages:
     source: hosted
     version: "3.1.3"
   uuid:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: uuid
       sha256: a5be9ef6618a7ac1e964353ef476418026db906c4facdedaa299b7a2e71690ff

--- a/faulkner_footsteps/pubspec.yaml
+++ b/faulkner_footsteps/pubspec.yaml
@@ -55,6 +55,7 @@ dependencies:
   geolocator: ^13.0.2
   flutter_map_location_marker: any
   image_picker: ^1.1.2
+  firebase_storage: ^12.4.4
 
 dev_dependencies:
   flutter_test:

--- a/faulkner_footsteps/pubspec.yaml
+++ b/faulkner_footsteps/pubspec.yaml
@@ -56,6 +56,7 @@ dependencies:
   flutter_map_location_marker: any
   image_picker: ^1.1.2
   firebase_storage: ^12.4.4
+  uuid: ^4.5.1
 
 dev_dependencies:
   flutter_test:

--- a/faulkner_footsteps/windows/flutter/generated_plugin_registrant.cc
+++ b/faulkner_footsteps/windows/flutter/generated_plugin_registrant.cc
@@ -12,6 +12,7 @@
 #include <file_selector_windows/file_selector_windows.h>
 #include <firebase_auth/firebase_auth_plugin_c_api.h>
 #include <firebase_core/firebase_core_plugin_c_api.h>
+#include <firebase_storage/firebase_storage_plugin_c_api.h>
 #include <geolocator_windows/geolocator_windows.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 
@@ -28,6 +29,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("FirebaseAuthPluginCApi"));
   FirebaseCorePluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FirebaseCorePluginCApi"));
+  FirebaseStoragePluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("FirebaseStoragePluginCApi"));
   GeolocatorWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("GeolocatorWindows"));
   UrlLauncherWindowsRegisterWithRegistrar(

--- a/faulkner_footsteps/windows/flutter/generated_plugins.cmake
+++ b/faulkner_footsteps/windows/flutter/generated_plugins.cmake
@@ -9,6 +9,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   file_selector_windows
   firebase_auth
   firebase_core
+  firebase_storage
   geolocator_windows
   url_launcher_windows
 )


### PR DESCRIPTION
Images are saved with a reference. That reference is stored in firebase. When a site is pulled from Firebase the reference is saved under the ImageURL field. After creation, the process of loading the image begins. While the image is not loaded, the basic thumbnail is loaded. Once the image loads, the thumbnail is replaced.

I had trouble making a good name for the image reference. Thus, each image name is stored with a uuid, which basically creates a unique name. HOWEVER, the folder name is currently set to be the name of the historical site. This is flawed because the name should be without spaces. However, all attempts to alter the string in such a way that the string has no spaces will not work- I have no clue why. This is the main reason I have held off on making a pull request for so long.

Additionally, the filter selection has been improved based on the criticism I have received in class.

closes #72
closes #75
closes #78