### PR TITLE
Added profile button to historical site page

### DIFF
--- a/faulkner_footsteps/lib/pages/hist_site_page.dart
+++ b/faulkner_footsteps/lib/pages/hist_site_page.dart
@@ -5,6 +5,7 @@ import 'package:faulkner_footsteps/app_state.dart';
 import 'package:faulkner_footsteps/main.dart';
 import 'package:faulkner_footsteps/objects/hist_site.dart';
 import 'package:faulkner_footsteps/pages/map_display.dart';
+import 'package:faulkner_footsteps/widgets/profile_button.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_rating/flutter_rating.dart';
@@ -126,6 +127,7 @@ class _HistSitePage extends State<HistSitePage> {
     return Scaffold(
         backgroundColor: Theme.of(context).colorScheme.surface,
         appBar: AppBar(
+          actions: [ProfileButton()],
           leading: BackButton(
               // color: Color.fromARGB(255, 255, 243, 228),
               ),
@@ -178,7 +180,7 @@ class _HistSitePage extends State<HistSitePage> {
                                                 backgroundColor:
                                                     Theme.of(context)
                                                         .colorScheme
-                                                        .onPrimary,
+                                                        .secondary,
                                                 elevation: 5.0,
                                                 title: Container(
                                                   constraints: BoxConstraints(


### PR DESCRIPTION
This will allow not logged in users to have a profile button right on the historical site page. This should provide ease of access so that they don't have to navigate back to the home page to log in or sign up. 
closes #179 

P.S. Sorry for taking your issue, I thought it was assigned to me lol