### PR TITLE
Admin page searchbar

### DIFF
--- a/faulkner_footsteps/lib/pages/admin_page.dart
+++ b/faulkner_footsteps/lib/pages/admin_page.dart
@@ -8,6 +8,7 @@ import 'package:faulkner_footsteps/objects/theme_data.dart';
 import 'package:faulkner_footsteps/pages/map_display.dart';
 import 'package:faulkner_footsteps/pages/admin_progress_achievements.dart';
 import 'package:faulkner_footsteps/widgets/list_edit.dart';
+import 'package:faulkner_footsteps/widgets/search_widget.dart';
 import 'package:firebase_storage/firebase_storage.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -47,9 +48,15 @@ class _AdminListPageState extends State<AdminListPage> {
   Map<String, List<ImageWithUrl>> tempImageChanges = {};
   Map<String, List<String>> tempDeletedUrls = {};
 
+  late SearchController _sitesSearchController;
+  late SearchController _achievementsSearchController;
+
+  @override
   @override
   void initState() {
     super.initState();
+    _sitesSearchController = SearchController();
+    _achievementsSearchController = SearchController();
   }
 
   void didChangeDependencies() {
@@ -557,6 +564,7 @@ class _AdminListPageState extends State<AdminListPage> {
   }
 
   Widget _buildAdminContent(BuildContext context) {
+    List<HistSite> displaySites = getSearchSites();
     return Column(
       children: [
         Padding(
@@ -591,9 +599,9 @@ class _AdminListPageState extends State<AdminListPage> {
           child: Consumer<ApplicationState>(
             builder: (context, appState, chile) {
               return ListView.builder(
-                itemCount: appState.historicalSites.length,
+                itemCount: displaySites.length,
                 itemBuilder: (BuildContext context, int index) {
-                  final site = appState.historicalSites[index];
+                  final site = displaySites[index];
                   return Card(
                     margin:
                         const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
@@ -1507,6 +1515,17 @@ class _AdminListPageState extends State<AdminListPage> {
     });
   }
 
+  List<HistSite> getSearchSites() {
+    if (_sitesSearchController.text.isEmpty) {
+      return context.read<ApplicationState>().historicalSites;
+    }
+    final query = _sitesSearchController.text.toLowerCase();
+    final allSites = context.read<ApplicationState>().historicalSites;
+    return allSites
+        .where((site) => site.name.toLowerCase().contains(query))
+        .toList();
+  }
+
   @override
   Widget build(BuildContext context) {
     return Theme(
@@ -1526,14 +1545,37 @@ class _AdminListPageState extends State<AdminListPage> {
           actions: [
             IconButton(
                 onPressed: () {
-                  print("pressed!");
+                  showDialog(
+                      context: context,
+                      builder: (context) {
+                        return SearchWidget(
+                            searchController: _selectedIndex == 0
+                                ? _sitesSearchController
+                                : _achievementsSearchController,
+                            onSearchSubmitted: () {
+                              setState(() {});
+                            },
+                            itemNames: _selectedIndex == 0
+                                ? context
+                                    .read<ApplicationState>()
+                                    .historicalSites
+                                    .map((site) => site.name)
+                                    .toList()
+                                : context
+                                    .read<ApplicationState>()
+                                    .progressAchievements
+                                    .map((achievement) => achievement.title)
+                                    .toList());
+                      });
                 },
                 icon: const Icon(Icons.search))
           ],
         ),
         body: _selectedIndex == 0
             ? _buildAdminContent(context)
-            : AdminProgressAchievements(),
+            : AdminProgressAchievements(
+                searchController: _achievementsSearchController,
+              ),
         bottomNavigationBar: BottomNavigationBar(
           backgroundColor: const Color.fromARGB(255, 218, 180, 130),
           selectedItemColor: const Color.fromARGB(255, 124, 54, 16),

--- a/faulkner_footsteps/lib/pages/admin_progress_achievements.dart
+++ b/faulkner_footsteps/lib/pages/admin_progress_achievements.dart
@@ -7,7 +7,8 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:provider/provider.dart';
 
 class AdminProgressAchievements extends StatefulWidget {
-  AdminProgressAchievements({super.key});
+  final SearchController searchController;
+  AdminProgressAchievements({super.key, required this.searchController});
 
   @override
   State<AdminProgressAchievements> createState() =>
@@ -15,7 +16,19 @@ class AdminProgressAchievements extends StatefulWidget {
 }
 
 class _AdminProgressAchievementsState extends State<AdminProgressAchievements> {
+  List<ProgressAchievement> getSearchAchievements() {
+    if (widget.searchController.text.isEmpty) {
+      return context.read<ApplicationState>().progressAchievements;
+    }
+    final query = widget.searchController.text.toLowerCase();
+    final allSites = context.read<ApplicationState>().progressAchievements;
+    return allSites
+        .where((site) => site.title.toLowerCase().contains(query))
+        .toList();
+  }
+
   Widget _buildAdminContent(BuildContext context, ApplicationState app_state) {
+    List<ProgressAchievement> displayAchievements = getSearchAchievements();
     return Column(
       children: [
         Padding(
@@ -37,7 +50,7 @@ class _AdminProgressAchievementsState extends State<AdminProgressAchievements> {
           ),
         ),
         Expanded(
-          child: app_state.progressAchievements.isEmpty
+          child: displayAchievements.isEmpty
               ? Center(
                   child: Text(
                     'No progress achievements yet',
@@ -45,9 +58,9 @@ class _AdminProgressAchievementsState extends State<AdminProgressAchievements> {
                   ),
                 )
               : ListView.builder(
-                  itemCount: app_state.progressAchievements.length,
+                  itemCount: displayAchievements.length,
                   itemBuilder: (BuildContext context, int index) {
-                    final achievement = app_state.progressAchievements[index];
+                    final achievement = displayAchievements[index];
                     return Card(
                       margin: const EdgeInsets.symmetric(
                           horizontal: 16, vertical: 8),

--- a/faulkner_footsteps/lib/pages/home_page.dart
+++ b/faulkner_footsteps/lib/pages/home_page.dart
@@ -263,6 +263,9 @@ class _HomePageState extends State<HomePage> {
                               onSearchSubmitted: () {
                                 setState(() {});
                               },
+                              itemNames: appState.historicalSites
+                                  .map((site) => site.name)
+                                  .toList(),
                             );
                           });
                     },

--- a/faulkner_footsteps/lib/widgets/search_widget.dart
+++ b/faulkner_footsteps/lib/widgets/search_widget.dart
@@ -4,12 +4,16 @@ import 'package:provider/provider.dart';
 
 class SearchWidget extends StatelessWidget {
   final SearchController searchController;
-  final Function() onSearchSubmitted;
+  final Function()
+      onSearchSubmitted; // in case there needs to be some additional logic when search is submitted. This allows for that.
+
+  final List<String> itemNames; // the list of items to search through
 
   const SearchWidget(
       {super.key,
       required this.searchController,
-      required this.onSearchSubmitted});
+      required this.onSearchSubmitted,
+      required this.itemNames});
   @override
   Widget build(BuildContext context) {
     return AlertDialog(
@@ -88,22 +92,22 @@ class SearchWidget extends StatelessWidget {
         },
         suggestionsBuilder: (context, controller) {
           final query = controller.text.toLowerCase();
-          final allSites = context.read<ApplicationState>().historicalSites;
-          final matches = allSites
-              .where((site) => site.name.toLowerCase().contains(query))
+          final allItems = itemNames;
+          final matches = allItems
+              .where((item) => item.toLowerCase().contains(query))
               .toList();
 
-          return matches.map((site) {
+          return matches.map((item) {
             return ListTile(
               title: Text(
-                site.name,
+                item,
                 style: Theme.of(context).textTheme.bodySmall?.copyWith(
                       color: Theme.of(context).colorScheme.secondary,
                     ),
               ),
               onTap: () {
-                searchController.text = site.name;
-                controller.closeView(site.name);
+                searchController.text = item;
+                controller.closeView(item);
                 onSearchSubmitted();
                 Navigator.pop(context);
               },


### PR DESCRIPTION
Adds searchbar to admin page. Applies to both historical sites and progress achievements. I noticed that as the site list got bigger and bigger, it may be a pain to have to scroll and look for whatever site to edit. Hopefully this is a small improvement that helps with that. 
I extracted the search dialog on the main page to its own stateless widget that takes in a searchcontroller and list of item strings. When search is used, a the searchcontroller knows the query and when it is submitted, a function is used to pick all sites or achievements with the query in the name. 

closes #228 