### PR TITLE
Moved search sites display list into consumer

### DIFF
--- a/faulkner_footsteps/lib/pages/admin_page.dart
+++ b/faulkner_footsteps/lib/pages/admin_page.dart
@@ -564,7 +564,6 @@ class _AdminListPageState extends State<AdminListPage> {
   }
 
   Widget _buildAdminContent(BuildContext context) {
-    List<HistSite> displaySites = getSearchSites();
     return Column(
       children: [
         Padding(
@@ -598,6 +597,8 @@ class _AdminListPageState extends State<AdminListPage> {
         Expanded(
           child: Consumer<ApplicationState>(
             builder: (context, appState, chile) {
+              List<HistSite> displaySites = getSearchSites();
+
               return ListView.builder(
                 itemCount: displaySites.length,
                 itemBuilder: (BuildContext context, int index) {
@@ -1292,10 +1293,10 @@ class _AdminListPageState extends State<AdminListPage> {
                                         ),
                                       ),
                                       onDeleted: () {
-                                          setState(() {
-                                            chosenFilters.remove(filter);
-                                          });
-                                        },
+                                        setState(() {
+                                          chosenFilters.remove(filter);
+                                        });
+                                      },
                                       backgroundColor: const Color.fromARGB(
                                           255, 107, 79, 79),
                                     );


### PR DESCRIPTION
Stupid issue was created when I added the searchbar. When editing sites, the list would not update immediately. This is because when I created the display lists that would be filtered by the search query, I didn't define the display list inside the consumer. Very silly mistake. 

closes #236 