### PR TITLE
Profile page

### DIFF
--- a/faulkner_footsteps/lib/app_state.dart
+++ b/faulkner_footsteps/lib/app_state.dart
@@ -13,6 +13,7 @@ import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_storage/firebase_storage.dart';
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 import 'package:flutter/material.dart';
+import 'package:geolocator/geolocator.dart';
 import 'package:latlong2/latlong.dart';
 
 import 'firebase_options.dart';
@@ -43,6 +44,13 @@ class ApplicationState extends ChangeNotifier {
 
   List<ProgressAchievement> _progressAchievements = [];
   List<ProgressAchievement> get progressAchievements => _progressAchievements;
+
+  LocationPermission _permission = LocationPermission.denied;
+  LocationPermission get permissionStatus => _permission;
+
+  LatLng _fallback = const LatLng(35.0918, -92.4367);
+  LatLng _currentLocation = const LatLng(35.0918, -92.4367);
+  LatLng get currentLocation => _currentLocation;
 
   Future<void> init() async {
     print(" 🔵 Initializing ApplicationState at ${DateTime.now()}");
@@ -551,5 +559,39 @@ class ApplicationState extends ChangeNotifier {
       i++;
     }
     return sites;
+  }
+
+  Future<void> updateUserLocation() async {
+    bool serviceEnabled = await Geolocator.isLocationServiceEnabled();
+    if (!serviceEnabled) {
+      _currentLocation = _fallback;
+      notifyListeners();
+      return;
+    }
+
+    _permission = await Geolocator.checkPermission();
+    if (_permission == LocationPermission.denied) {
+      _permission = await Geolocator.requestPermission();
+      if (_permission == LocationPermission.denied) {
+        _currentLocation = _fallback;
+        notifyListeners();
+        return;
+      }
+    }
+
+    if (_permission == LocationPermission.deniedForever) {
+      _currentLocation = _fallback;
+      notifyListeners();
+      return;
+    }
+
+    final pos = await Geolocator.getCurrentPosition(
+      locationSettings: const LocationSettings(
+        accuracy: LocationAccuracy.high,
+      ),
+    );
+
+    _currentLocation = LatLng(pos.latitude, pos.longitude);
+    notifyListeners();
   }
 }

--- a/faulkner_footsteps/lib/app_state.dart
+++ b/faulkner_footsteps/lib/app_state.dart
@@ -562,6 +562,7 @@ class ApplicationState extends ChangeNotifier {
   }
 
   Future<void> updateUserLocation() async {
+    print("call update user location");
     bool serviceEnabled = await Geolocator.isLocationServiceEnabled();
     if (!serviceEnabled) {
       _currentLocation = _fallback;
@@ -593,5 +594,30 @@ class ApplicationState extends ChangeNotifier {
 
     _currentLocation = LatLng(pos.latitude, pos.longitude);
     notifyListeners();
+  }
+
+  Future<void> ensureLocationPermission() async {
+    // print("calls ensure location permission");
+    // print("Permission: ${_permission}");
+    // final permission = await Geolocator.checkPermission();
+    // print("Result permission: ${permission}");
+    // _permission = permission;
+
+    if (_permission == LocationPermission.denied) {
+      final newPermission = await Geolocator.requestPermission();
+      if (newPermission == LocationPermission.denied) {
+        return; // user denied again
+      }
+      _permission = newPermission;
+      await updateUserLocation();
+      return;
+    }
+
+    if (_permission == LocationPermission.deniedForever) {
+      // print("Reached!!!");
+      await Geolocator.openAppSettings();
+      await updateUserLocation();
+      return;
+    }
   }
 }

--- a/faulkner_footsteps/lib/app_state.dart
+++ b/faulkner_footsteps/lib/app_state.dart
@@ -565,6 +565,7 @@ class ApplicationState extends ChangeNotifier {
     print("call update user location");
     bool serviceEnabled = await Geolocator.isLocationServiceEnabled();
     if (!serviceEnabled) {
+      print("Service not enabled!");
       _currentLocation = _fallback;
       notifyListeners();
       return;
@@ -572,8 +573,10 @@ class ApplicationState extends ChangeNotifier {
 
     _permission = await Geolocator.checkPermission();
     if (_permission == LocationPermission.denied) {
+      print("Permissions are denied");
       _permission = await Geolocator.requestPermission();
       if (_permission == LocationPermission.denied) {
+        print("Permissions are still denied");
         _currentLocation = _fallback;
         notifyListeners();
         return;
@@ -581,11 +584,12 @@ class ApplicationState extends ChangeNotifier {
     }
 
     if (_permission == LocationPermission.deniedForever) {
+      print("permissions are denied forever");
       _currentLocation = _fallback;
       notifyListeners();
       return;
     }
-
+    print("permissions allow getting of current position");
     final pos = await Geolocator.getCurrentPosition(
       locationSettings: const LocationSettings(
         accuracy: LocationAccuracy.high,
@@ -609,14 +613,14 @@ class ApplicationState extends ChangeNotifier {
         return; // user denied again
       }
       _permission = newPermission;
-      await updateUserLocation();
+      // await updateUserLocation();
       return;
     }
 
     if (_permission == LocationPermission.deniedForever) {
       // print("Reached!!!");
       await Geolocator.openAppSettings();
-      await updateUserLocation();
+      // await updateUserLocation();
       return;
     }
   }

--- a/faulkner_footsteps/lib/app_state.dart
+++ b/faulkner_footsteps/lib/app_state.dart
@@ -300,7 +300,7 @@ class ApplicationState extends ChangeNotifier {
   //update/store rating in firebase
   void updateSiteRating(String siteName, double newRating) async {
     try {
-      print("reached here!");
+      // print("reached here!");
       final site = _historicalSites.firstWhere((s) => s.name == siteName);
       final userId = FirebaseAuth.instance.currentUser!.uid;
       double totalRating = 0;

--- a/faulkner_footsteps/lib/pages/admin_page.dart
+++ b/faulkner_footsteps/lib/pages/admin_page.dart
@@ -60,54 +60,6 @@ class _AdminListPageState extends State<AdminListPage> {
     // });
   }
 
-  Future<void> pickImages() async {
-    final int maxBytes = 1024 * 1024; // 1 MB
-    try {
-      final pickedImages = await ImagePicker().pickMultiImage();
-      if (pickedImages.isEmpty) return;
-
-      List<File> finalImages = [];
-
-      for (XFile image in pickedImages) {
-        final file = File(image.path);
-        final fileSize = await file.length();
-
-        if (fileSize > maxBytes) {
-          final compressed = await compressAndGetFile(file);
-          if (compressed != null) {
-            finalImages.add(compressed);
-          } else {
-            print("Compression failed for ${image.name}");
-          }
-        } else {
-          finalImages.add(file);
-        }
-      }
-
-      this.images = finalImages;
-      setState(() {});
-    } on PlatformException catch (e) {
-      print("Failed to pick images: $e");
-    }
-  }
-
-  Future<File?> compressAndGetFile(File file,
-      {int quality = 75, int maxWidth = 1280}) async {
-    final tempDir = await getTemporaryDirectory();
-    final targetPath =
-        '${tempDir.path}/${DateTime.now().millisecondsSinceEpoch}.jpg';
-
-    XFile? result = await FlutterImageCompress.compressAndGetFile(
-      file.absolute.path,
-      targetPath,
-      quality: quality,
-      minWidth: maxWidth,
-      minHeight: (maxWidth * 0.75).toInt(),
-      format: CompressFormat.jpeg,
-    );
-    return result != null ? File(result.path) : null;
-  }
-
   Future<List<String>> uploadImages(String folderName, List<String> fileNames,
       {List<File>? files}) async {
     print("begun uploading images");

--- a/faulkner_footsteps/lib/pages/home_page.dart
+++ b/faulkner_footsteps/lib/pages/home_page.dart
@@ -32,7 +32,6 @@ class _HomePageState extends State<HomePage> {
   late var sorted;
 
   void initState() {
-    getlocation();
     super.initState();
   }
 
@@ -44,6 +43,7 @@ class _HomePageState extends State<HomePage> {
     appState = Provider.of<ApplicationState>(context, listen: false);
     setState(() {
       activeFilters.clear();
+      getlocation();
     });
 
     _searchController = SearchController();

--- a/faulkner_footsteps/lib/pages/home_page.dart
+++ b/faulkner_footsteps/lib/pages/home_page.dart
@@ -6,7 +6,6 @@ import 'package:faulkner_footsteps/pages/map_display.dart';
 import 'package:faulkner_footsteps/widgets/profile_button.dart';
 import 'package:faulkner_footsteps/widgets/search_widget.dart';
 import 'package:flutter/material.dart';
-import 'package:geolocator/geolocator.dart';
 import 'package:latlong2/latlong.dart';
 import 'package:provider/provider.dart';
 
@@ -21,45 +20,9 @@ class _HomePageState extends State<HomePage> {
   Set<SiteFilter> activeFilters = {};
 
   late ApplicationState appState;
-  static LatLng? _currentPosition;
 
   void getlocation() async {
-    bool serviceEnabled;
-    double lat = 35.0918;
-    double long = -92.4367;
-    LocationPermission permission;
-    serviceEnabled = await Geolocator.isLocationServiceEnabled();
-    if (!serviceEnabled) {
-      return setState(() {
-      _currentPosition = LatLng(lat, long);
-    });
-    }
-    permission = await Geolocator.checkPermission();
-    if (permission == LocationPermission.denied) {
-      permission = await Geolocator.requestPermission();
-      if (permission == LocationPermission.denied) {
-       return setState(() {
-      _currentPosition = LatLng(lat, long);
-    });
-      }
-    }
-    if (permission == LocationPermission.deniedForever) {
-      return setState(() {
-      _currentPosition = LatLng(lat, long);
-    });
-    }
-    final LocationSettings locationSettings = LocationSettings(
-      accuracy: LocationAccuracy.high,
-    );
-    if (permission == LocationPermission.whileInUse || permission == LocationPermission.always){
-       Position position =
-        await Geolocator.getCurrentPosition(locationSettings: locationSettings);
-     lat = position.latitude;
-     long = position.longitude;
-    }
-    setState(() {
-      _currentPosition = LatLng(lat, long);
-    });
+    appState.updateUserLocation();
   }
 
   late SearchController _searchController;
@@ -91,8 +54,8 @@ class _HomePageState extends State<HomePage> {
   Map<String, double> getDistances(Map<String, LatLng> locations) {
     Map<String, double> distances = {};
     for (int i = 0; i < locations.length; i++) {
-      distances[locations.keys.elementAt(i)] = distance.as(
-          LengthUnit.Meter, locations.values.elementAt(i), _currentPosition!);
+      distances[locations.keys.elementAt(i)] = distance.as(LengthUnit.Meter,
+          locations.values.elementAt(i), appState.currentLocation);
     }
     return distances;
   }
@@ -128,18 +91,16 @@ class _HomePageState extends State<HomePage> {
     }
 
     // Optional: apply sorting
-    if (_currentPosition != null) {
-      final locations = appState.getLocations();
-      final distances = getDistances(locations);
-      filtered.sort((a, b) => distances[a.name]!.compareTo(distances[b.name]!));
-    }
+    final locations = appState.getLocations();
+    final distances = getDistances(locations);
+    filtered.sort((a, b) => distances[a.name]!.compareTo(distances[b.name]!));
 
     return filtered;
   }
 
   @override
   Widget build(BuildContext context) {
-    while (_currentPosition == null) {
+    while (appState.currentLocation == null) {
       return Center(
         child: CircularProgressIndicator(),
       );
@@ -187,7 +148,7 @@ class _HomePageState extends State<HomePage> {
                   sites: getFilteredSites(appState.historicalSites),
                   siteFilters: appState.siteFilters.toSet(),
                   activeFilters: activeFilters,
-                  currentPosition: _currentPosition!,
+                  currentPosition: appState.currentLocation,
                   onFilterChanged: (filter) {
                     setState(() {
                       !activeFilters.contains(filter)
@@ -203,9 +164,9 @@ class _HomePageState extends State<HomePage> {
                   },
                 )
               : MapDisplay2(
-                  currentPosition: _currentPosition!,
+                  currentPosition: appState.currentLocation,
                   sites: getFilteredSites(appState.historicalSites),
-                  centerPosition: _currentPosition!,
+                  centerPosition: appState.currentLocation,
                 ),
           bottomNavigationBar: BottomNavigationBar(
             type: BottomNavigationBarType.fixed,

--- a/faulkner_footsteps/lib/pages/profile_page.dart
+++ b/faulkner_footsteps/lib/pages/profile_page.dart
@@ -378,6 +378,8 @@ class _ProfilePageState extends State<ProfilePage>
                         style: Theme.of(context).textTheme.bodyLarge?.copyWith(
                             color: Theme.of(context).colorScheme.onPrimary)),
                     children: [
+                      const SizedBox(height: 24),
+
                       if (appState.permissionStatus ==
                               LocationPermission.denied ||
                           appState.permissionStatus ==
@@ -432,6 +434,8 @@ class _ProfilePageState extends State<ProfilePage>
                             ),
                           ),
                         ),
+                      const SizedBox(height: 24),
+
                       // Change Passowrd
                       Container(
                         width: cardWidth / 1.05,

--- a/faulkner_footsteps/lib/pages/profile_page.dart
+++ b/faulkner_footsteps/lib/pages/profile_page.dart
@@ -5,6 +5,7 @@ import 'package:faulkner_footsteps/pages/login_page.dart';
 import 'package:faulkner_footsteps/widgets/achievement_item.dart';
 import 'package:flutter/material.dart';
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:geolocator/geolocator.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:provider/provider.dart';
 import 'package:faulkner_footsteps/app_state.dart';
@@ -357,9 +358,10 @@ class _ProfilePageState extends State<ProfilePage>
                     ),
                   ),
                 ),
+
                 const SizedBox(height: 24),
 
-                // Password card
+                // Account Actions card
                 ExpansionTile(
                     shape: RoundedRectangleBorder(
                       borderRadius: BorderRadius.circular(12.0),
@@ -376,6 +378,59 @@ class _ProfilePageState extends State<ProfilePage>
                         style: Theme.of(context).textTheme.bodyLarge?.copyWith(
                             color: Theme.of(context).colorScheme.onPrimary)),
                     children: [
+                      if (appState.permissionStatus ==
+                              LocationPermission.denied ||
+                          appState.permissionStatus ==
+                              LocationPermission.deniedForever)
+                        Container(
+                          width: cardWidth / 1.05,
+                          child: Card(
+                            elevation: 2.0,
+                            color: Theme.of(context).colorScheme.primary,
+                            shape: RoundedRectangleBorder(
+                              side: BorderSide(
+                                color: Theme.of(context).colorScheme.outline,
+                              ),
+                              borderRadius: BorderRadius.circular(12.0),
+                            ),
+                            margin: EdgeInsets.zero,
+                            child: Padding(
+                              padding:
+                                  EdgeInsetsGeometry.symmetric(vertical: 16.0),
+                              child: Column(
+                                children: [
+                                  Text("Permissions are disabled"),
+                                  ElevatedButton(
+                                    onPressed: () =>
+                                        appState.ensureLocationPermission(),
+                                    child: Text(
+                                      appState.permissionStatus ==
+                                              LocationPermission.denied
+                                          ? "Allow Permissions"
+                                          : "Go to Settings",
+                                      style: GoogleFonts.rakkas(
+                                        textStyle: TextStyle(
+                                          color: Theme.of(context)
+                                              .colorScheme
+                                              .primary,
+                                          fontSize: 16,
+                                        ),
+                                      ),
+                                    ),
+                                    style: ElevatedButton.styleFrom(
+                                      backgroundColor: Theme.of(context)
+                                          .colorScheme
+                                          .onPrimary,
+                                      padding: const EdgeInsets.symmetric(
+                                          vertical: 16),
+                                    ),
+                                  )
+                                ],
+                              ),
+                            ),
+                          ),
+                        ),
+                      // Change Passowrd
                       Container(
                         width: cardWidth / 1.05,
                         child: Card(

--- a/faulkner_footsteps/lib/pages/profile_page.dart
+++ b/faulkner_footsteps/lib/pages/profile_page.dart
@@ -395,34 +395,36 @@ class _ProfilePageState extends State<ProfilePage>
                             ),
                             margin: EdgeInsets.zero,
                             child: Padding(
-                              padding:
-                                  EdgeInsetsGeometry.symmetric(vertical: 16.0),
+                              padding: EdgeInsetsGeometry.all(16.0),
                               child: Column(
                                 children: [
                                   Text("Permissions are disabled"),
-                                  ElevatedButton(
-                                    onPressed: () =>
-                                        appState.ensureLocationPermission(),
-                                    child: Text(
-                                      appState.permissionStatus ==
-                                              LocationPermission.denied
-                                          ? "Allow Permissions"
-                                          : "Go to Settings",
-                                      style: GoogleFonts.rakkas(
-                                        textStyle: TextStyle(
-                                          color: Theme.of(context)
-                                              .colorScheme
-                                              .primary,
-                                          fontSize: 16,
+                                  SizedBox(
+                                    width: double.infinity,
+                                    child: ElevatedButton(
+                                      onPressed: () =>
+                                          appState.ensureLocationPermission(),
+                                      child: Text(
+                                        appState.permissionStatus ==
+                                                LocationPermission.denied
+                                            ? "Allow Permissions"
+                                            : "Go to Settings",
+                                        style: GoogleFonts.rakkas(
+                                          textStyle: TextStyle(
+                                            color: Theme.of(context)
+                                                .colorScheme
+                                                .primary,
+                                            fontSize: 16,
+                                          ),
                                         ),
                                       ),
-                                    ),
-                                    style: ElevatedButton.styleFrom(
-                                      backgroundColor: Theme.of(context)
-                                          .colorScheme
-                                          .onPrimary,
-                                      padding: const EdgeInsets.symmetric(
-                                          vertical: 16),
+                                      style: ElevatedButton.styleFrom(
+                                        backgroundColor: Theme.of(context)
+                                            .colorScheme
+                                            .onPrimary,
+                                        padding: const EdgeInsets.symmetric(
+                                            vertical: 16),
+                                      ),
                                     ),
                                   )
                                 ],

--- a/faulkner_footsteps/lib/pages/profile_page.dart
+++ b/faulkner_footsteps/lib/pages/profile_page.dart
@@ -381,9 +381,9 @@ class _ProfilePageState extends State<ProfilePage>
                       const SizedBox(height: 24),
 
                       if (appState.permissionStatus ==
-                              LocationPermission.denied ||
+                              LocationPermission.deniedForever ||
                           appState.permissionStatus ==
-                              LocationPermission.deniedForever)
+                              LocationPermission.denied) ...[
                         Container(
                           width: cardWidth / 1.05,
                           child: Card(
@@ -401,16 +401,42 @@ class _ProfilePageState extends State<ProfilePage>
                               child: Column(
                                 children: [
                                   Text("Permissions are disabled"),
+                                  if (appState.permissionStatus ==
+                                      LocationPermission.deniedForever) ...[
+                                    SizedBox(
+                                      width: double.infinity,
+                                      child: ElevatedButton(
+                                        onPressed: () =>
+                                            appState.ensureLocationPermission(),
+                                        child: Text(
+                                          "Go to Settings",
+                                          style: GoogleFonts.rakkas(
+                                            textStyle: TextStyle(
+                                              color: Theme.of(context)
+                                                  .colorScheme
+                                                  .primary,
+                                              fontSize: 16,
+                                            ),
+                                          ),
+                                        ),
+                                        style: ElevatedButton.styleFrom(
+                                          backgroundColor: Theme.of(context)
+                                              .colorScheme
+                                              .onPrimary,
+                                          padding: const EdgeInsets.symmetric(
+                                              vertical: 16),
+                                        ),
+                                      ),
+                                    ),
+                                    const SizedBox(height: 24)
+                                  ],
                                   SizedBox(
                                     width: double.infinity,
                                     child: ElevatedButton(
                                       onPressed: () =>
-                                          appState.ensureLocationPermission(),
+                                          appState.updateUserLocation(),
                                       child: Text(
-                                        appState.permissionStatus ==
-                                                LocationPermission.denied
-                                            ? "Allow Permissions"
-                                            : "Go to Settings",
+                                        "Request Permissions",
                                         style: GoogleFonts.rakkas(
                                           textStyle: TextStyle(
                                             color: Theme.of(context)
@@ -434,7 +460,8 @@ class _ProfilePageState extends State<ProfilePage>
                             ),
                           ),
                         ),
-                      const SizedBox(height: 24),
+                        const SizedBox(height: 24),
+                      ],
 
                       // Change Passowrd
                       Container(

--- a/faulkner_footsteps/lib/pages/profile_page.dart
+++ b/faulkner_footsteps/lib/pages/profile_page.dart
@@ -1,5 +1,5 @@
 import 'package:faulkner_footsteps/app_router.dart';
- import 'package:faulkner_footsteps/objects/theme_data.dart';
+import 'package:faulkner_footsteps/objects/theme_data.dart';
 import 'package:faulkner_footsteps/pages/admin_page.dart';
 import 'package:faulkner_footsteps/pages/login_page.dart';
 import 'package:faulkner_footsteps/widgets/achievement_item.dart';
@@ -305,9 +305,10 @@ class _ProfilePageState extends State<ProfilePage>
                                           .colorScheme
                                           .onPrimary)),
                           const SizedBox(height: 16),
-                          Consumer<ApplicationState>(
-                            builder: (context, appState, _) {
-                              if (appState.visitedPlaces.isEmpty) {
+                          Selector<ApplicationState, Set<String>>(
+                            selector: (_, appState) => appState.visitedPlaces,
+                            builder: (context, visitedSites, _) {
+                              if (visitedSites.isEmpty) {
                                 return Text(
                                   'You haven\'t visited any historical sites yet.',
                                   style: Theme.of(context)
@@ -320,44 +321,37 @@ class _ProfilePageState extends State<ProfilePage>
                                       ),
                                 );
                               }
-
-                              return Selector<ApplicationState, Set<String>>(
-                                selector: (_, appState) =>
-                                    appState.visitedPlaces,
-                                builder: (context, visitedSites, _) {
-                                  return Wrap(
-                                    spacing: 10,
-                                    runSpacing: 10,
-                                    children: appState.historicalSites
-                                        .where((site) =>
-                                            appState.hasVisited(site.name))
-                                        .map((place) {
-                                      return Chip(
-                                        backgroundColor: Colors.green[100],
-                                        avatar: Icon(
-                                          Icons.emoji_events,
-                                          color: Colors.green,
-                                          size: 18,
+                              return Wrap(
+                                spacing: 10,
+                                runSpacing: 10,
+                                children: appState.historicalSites
+                                    .where((site) =>
+                                        appState.hasVisited(site.name))
+                                    .map((place) {
+                                  return Chip(
+                                    backgroundColor: Colors.green[100],
+                                    avatar: Icon(
+                                      Icons.emoji_events,
+                                      color: Colors.green,
+                                      size: 18,
+                                    ),
+                                    label: Text(
+                                      place.name,
+                                      style: GoogleFonts.rakkas(
+                                        textStyle: TextStyle(
+                                          color: Theme.of(context)
+                                              .colorScheme
+                                              .secondary,
+                                          fontSize: 14,
                                         ),
-                                        label: Text(
-                                          place.name,
-                                          style: GoogleFonts.rakkas(
-                                            textStyle: TextStyle(
-                                              color: Theme.of(context)
-                                                  .colorScheme
-                                                  .secondary,
-                                              fontSize: 14,
-                                            ),
-                                          ),
-                                        ),
-                                        side: BorderSide(color: Colors.green),
-                                      );
-                                    }).toList(),
+                                      ),
+                                    ),
+                                    side: BorderSide(color: Colors.green),
                                   );
-                                },
+                                }).toList(),
                               );
                             },
-                          ),
+                          )
                         ],
                       ),
                     ),


### PR DESCRIPTION
Moved the permission tracking to appstate so that it can be shared across widgets. This allowed me to check if permissions were allowed on the profile page and add in buttons to either direct the user to their settings or to have the permission popup appear again. 
There are two buttons. If the permissions are marked as denied forever, then a button appears that directs the user to their settings so they can update their permissions. 
Another button just requests the permissions popup to appear again. This button is useless if the permissions are marked denied forever. 

closes #260 


