### PR TITLE
Dialogs cannot close by clicking outside their borders. 

### DIFF
--- a/faulkner_footsteps/lib/dialogs/edit_site_Dialog.dart
+++ b/faulkner_footsteps/lib/dialogs/edit_site_Dialog.dart
@@ -501,6 +501,7 @@ class _EditSiteDialogState extends State<EditSiteDialog> {
                             icon: const Icon(Icons.edit),
                             onPressed: () async {
                               final updated = await showDialog<InfoText>(
+                                barrierDismissible: false,
                                 context: context,
                                 builder: (context) => BlurbDialog(
                                   infoText: blurb,
@@ -532,6 +533,7 @@ class _EditSiteDialogState extends State<EditSiteDialog> {
                 ElevatedButton(
                   onPressed: () async {
                     final newBlurb = await showDialog<InfoText>(
+                      barrierDismissible: false,
                       context: context,
                       builder: (context) => BlurbDialog(),
                     );

--- a/faulkner_footsteps/lib/pages/admin_page.dart
+++ b/faulkner_footsteps/lib/pages/admin_page.dart
@@ -173,6 +173,7 @@ class _AdminListPageState extends State<AdminListPage> {
             ),
             onPressed: () {
               showDialog(
+                  barrierDismissible: false,
                   context: context,
                   builder: (context) {
                     return EditSiteDialog(
@@ -237,6 +238,7 @@ class _AdminListPageState extends State<AdminListPage> {
                         },
                         onEditSite: () {
                           showDialog(
+                              barrierDismissible: false,
                               context: context,
                               builder: (context) {
                                 return EditSiteDialog(


### PR DESCRIPTION
Dialogs would go away when clicked out of, these additions prevented that. When creating / editing a blurb or working on the edit / add site dialog, if the user clicked outside the dialog then the dialog would close. This is annoying and has the potential to cause lots of work to be lost. By adding this, the only way to close the dialog is by pressing submit or cancel which should help prevent accidental closures. 

On a sidenote, I think that we actually had this in place before admin page got refactored, but the glitch slipped back in after the refactor. 